### PR TITLE
Adição de flags e pilha ao simulador

### DIFF
--- a/t0/.gitignore
+++ b/t0/.gitignore
@@ -1,0 +1,4 @@
+*.o
+*.maq
+*.exe
+.vscode

--- a/t0/Makefile
+++ b/t0/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 CFLAGS = -Wall -Werror
 
 OBJS = exec.o cpu_estado.o es.o mem.o rel.o term.o teste.o
-MAQS = ex1.maq ex2.maq
+MAQS = ex1.maq ex2.maq ex3.maq
 TARGETS = teste montador
 
 all: ${TARGETS}

--- a/t0/README.md
+++ b/t0/README.md
@@ -45,6 +45,10 @@ Ao final da execução bem sucedida de uma instrução, caso não seja uma instr
 |     18 | DESVNZ | 1    | se A não for 0, PC=A1 | desvio condicional |
 |     19 | LE     | 1    | A=es[A1]   | leitura de E/S |
 |     20 | ESCR   | 1    | es[A1]=A   | escrita de E/S |
+|     21 | CMP    | 1    | FLAGS=cmp(A,[A1]) | compara e define as flags de acordo |
+|     22 | DESVA  | 1    | se o bit de A>[A1] estiver definido nas flags, PC=A1 | desvio condicional |
+|     23 | DESVB  | 1    | se o bit de A<[A1] estiver definido nas flags, PC=A1 | desvio condicional |
+|     24 | DESVE  | 1    | se o bit de A=[A1] estiver definido nas flags, PC=A1 | desvio condicional |
 
 A CPU só executa uma instrução se o registrador de erro indicar que a CPU não está em erro (valor ERR_OK).
 A execução de uma instrução pode colocar a CPU em erro, por tentativa de execução de instrução ilegal, acesso a posição inválida de memória, acesso a dispositivo de E/S inexistente, etc. 
@@ -58,6 +62,7 @@ A implementação está dividida em vários módulos:
 - term, um terminal
 - cpu_estado, mantém o estado interno da CPU
 - err.h, define um tipo para codificar os erros
+- opcode.h, padroniza o opcode dos comandos tanto para o montador quanto para o executador
 - teste.c, um programa para testar os módulos acima, executando um programa (tá executando o ex1, para executar o ex2 tem que alterar o fonte)
 - ex1 e ex2.asm, dois programinhas de teste em linguagem de montagem
 - montador.c, um montador para transformar programas .asm em .maq (em linguagem de máquina)

--- a/t0/cpu_estado.c
+++ b/t0/cpu_estado.c
@@ -6,6 +6,7 @@ struct cpu_estado_t {
   int PC;
   int A;
   int X;
+  int SP;
   /**
    * Bits:
    * 0 - A maior
@@ -57,6 +58,10 @@ int cpue_X(cpu_estado_t *self)
   return self->X;
 }
 
+int cpue_SP(cpu_estado_t *self){
+  return self->SP;
+}
+
 err_t cpue_erro(cpu_estado_t *self)
 {
   return self->erro;
@@ -80,6 +85,10 @@ void cpue_muda_A(cpu_estado_t *self, int val)
 void cpue_muda_X(cpu_estado_t *self, int val)
 {
   self->X = val;
+}
+
+void cpue_muda_SP(cpu_estado_t *self,int val){
+  self->SP = val;
 }
 
 void cpue_muda_erro(cpu_estado_t *self, err_t err, int complemento)

--- a/t0/cpu_estado.c
+++ b/t0/cpu_estado.c
@@ -6,6 +6,14 @@ struct cpu_estado_t {
   int PC;
   int A;
   int X;
+  /**
+   * Bits:
+   * 0 - A maior
+   * 1 - Dado é maior
+   * 2 - A e Dado são iguais
+   **/
+  short FLAGS;
+  
   err_t erro;
   int complemento;
 };
@@ -80,3 +88,21 @@ void cpue_muda_erro(cpu_estado_t *self, err_t err, int complemento)
   self->complemento = complemento;
 }
 
+void cpue_define_status_flag(cpu_estado_t *self,int val){
+  if(val==0){
+      self->FLAGS = 1<<2; // Define a flag de igual
+  }else if (val>0){
+      self->FLAGS = 1<<0; // Define de maior
+  }else{
+      self->FLAGS = 1<<1; // Define de menor
+  }
+}
+short cpue_verifica_igual_flag(cpu_estado_t *self){
+  return self->FLAGS&(1<<2);
+}
+short cpue_verifica_maior_flag(cpu_estado_t *self){
+  return self->FLAGS&(1<<0);
+}
+short cpue_verifica_menor_flag(cpu_estado_t *self){
+  return self->FLAGS&(1<<1);
+}

--- a/t0/cpu_estado.h
+++ b/t0/cpu_estado.h
@@ -25,6 +25,8 @@ int cpue_PC(cpu_estado_t *self);
 int cpue_A(cpu_estado_t *self);
 // retorna o valor do registrador 'X'
 int cpue_X(cpu_estado_t *self);
+// retorna o valor do registrador 'X'
+int cpue_SP(cpu_estado_t *self);
 // retorna o valor do erro interno da CPU
 err_t cpue_erro(cpu_estado_t *self);
 // retorna o valor do complemento do erro (por exemplo, o endereço em que ocorreu um erro
@@ -35,11 +37,13 @@ int cpue_complemento(cpu_estado_t *self);
 void cpue_muda_PC(cpu_estado_t *self, int val);
 void cpue_muda_A(cpu_estado_t *self, int val);
 void cpue_muda_X(cpu_estado_t *self, int val);
+void cpue_muda_SP(cpu_estado_t *self,int val);
 void cpue_muda_erro(cpu_estado_t *self, err_t err, int complemento);
 
 void cpue_define_status_flag(cpu_estado_t *self,int val);
 short cpue_verifica_igual_flag(cpu_estado_t *self);
 short cpue_verifica_maior_flag(cpu_estado_t *self);
 short cpue_verifica_menor_flag(cpu_estado_t *self);
+
 
 #endif // CPU_E_H

--- a/t0/cpu_estado.h
+++ b/t0/cpu_estado.h
@@ -36,4 +36,10 @@ void cpue_muda_PC(cpu_estado_t *self, int val);
 void cpue_muda_A(cpu_estado_t *self, int val);
 void cpue_muda_X(cpu_estado_t *self, int val);
 void cpue_muda_erro(cpu_estado_t *self, err_t err, int complemento);
+
+void cpue_define_status_flag(cpu_estado_t *self,int val);
+short cpue_verifica_igual_flag(cpu_estado_t *self);
+short cpue_verifica_maior_flag(cpu_estado_t *self);
+short cpue_verifica_menor_flag(cpu_estado_t *self);
+
 #endif // CPU_E_H

--- a/t0/err.h
+++ b/t0/err.h
@@ -8,6 +8,7 @@ typedef enum {
   ERR_OP_INV,        // operação inválida
   ERR_CPU_PARADA,    // CPU está com execução suspensa
   ERR_INSTR_INV,     // instrução inválida
+  ERR_ESTOURO_PILHA, // estouro da pilha
 } err_t;
 
 #endif // ERR_H

--- a/t0/ex2.asm
+++ b/t0/ex2.asm
@@ -3,11 +3,11 @@
 ;   (no programa de teste, esses dispositivos são conectados ao relógio,
 ;   o 1 obtém o contador de instruções, o 2 o tempo externo de CPU)
 
-N    DEFINE 10
+N    DEFINE 4
      CARGI 0
      MVAX         ; x=0
      CARGI N
-     ARMM cont    ; cont=10
+     ARMM cont    ; cont=4
 ali  MVXA
      ESCR 0       ; print x
      LE 1
@@ -16,7 +16,8 @@ ali  MVXA
      ESCR 0
      INCX         ; x++
      MVXA
-     SUB cont
-     DESVNZ ali   ; if x != cont goto ali
+     CMPA cont  ; faz cmp A,[A1]
+     DESVE ali   ; if A = [cont] goto ali
+     DESVB ali   ; if A < [cont] goto ali
      PARA         ; stop
 cont ESPACO 1

--- a/t0/ex3.asm
+++ b/t0/ex3.asm
@@ -1,0 +1,13 @@
+     CARGI 128
+loop PUSHA
+     RESTO dez
+     ESCR 0
+     POPA
+     DIV dez
+     CMPA zero
+     DESVE fim
+     DESV loop
+fim  PARA         ; stop
+
+dez  VALOR 10
+zero VALOR 0

--- a/t0/ex3.asm
+++ b/t0/ex3.asm
@@ -1,3 +1,6 @@
+     CARGI 15
+     MVAX
+     PUSHX
      CARGI 128
 loop PUSHA
      RESTO dez
@@ -7,7 +10,9 @@ loop PUSHA
      CMPA zero
      DESVE fim
      DESV loop
-fim  PARA         ; stop
+fim  POPA
+     ESCR 0
+     PARA         ; stop
 
 dez  VALOR 10
 zero VALOR 0

--- a/t0/exec.c
+++ b/t0/exec.c
@@ -309,30 +309,51 @@ static void op_DESVE(exec_t *self) // desvio condicional
     incrementa_PC2(self);
   }
 }
-static void op_PUSHA(exec_t *self) // desvio condicional
+static void op_PUSHA(exec_t *self)
 {
   int sp = cpue_SP(self->estado);
   if(poe_mem(self, sp,cpue_A(self->estado))){
     cpue_muda_SP(self->estado,sp+1);
-    incrementa_PC2(self);
+    incrementa_PC(self);
   }else{
     cpue_muda_erro(self->estado, ERR_ESTOURO_PILHA, sp);
   }
 }
-static void op_POPA(exec_t *self) // desvio condicional
+static void op_POPA(exec_t *self)
 {
   int sp = cpue_SP(self->estado);
   int val;
   if(mem_heap(self->mem)<sp && pega_mem(self, sp-1,&val)){
     cpue_muda_SP(self->estado,sp-1);
     cpue_muda_A(self->estado,val);
-    incrementa_PC2(self);
+    incrementa_PC(self);
   }else{
     cpue_muda_erro(self->estado, ERR_ESTOURO_PILHA, sp);
   }
 }
 
-#include <stdio.h>
+static void op_PUSHX(exec_t *self)
+{
+  int sp = cpue_SP(self->estado);
+  if(poe_mem(self, sp,cpue_X(self->estado))){
+    cpue_muda_SP(self->estado,sp+1);
+    incrementa_PC(self);
+  }else{
+    cpue_muda_erro(self->estado, ERR_ESTOURO_PILHA, sp);
+  }
+}
+static void op_POPX(exec_t *self)
+{
+  int sp = cpue_SP(self->estado);
+  int val;
+  if(mem_heap(self->mem)<sp && pega_mem(self, sp-1,&val)){
+    cpue_muda_SP(self->estado,sp-1);
+    cpue_muda_X(self->estado,val);
+    incrementa_PC(self);
+  }else{
+    cpue_muda_erro(self->estado, ERR_ESTOURO_PILHA, sp);
+  }
+}
 
 
 err_t exec_executa_1(exec_t *self)
@@ -371,6 +392,8 @@ err_t exec_executa_1(exec_t *self)
     case DESVE:  op_DESVE(self);  break;
     case POPA:   op_POPA(self);   break;
     case PUSHA:  op_PUSHA(self);  break;
+    case POPX:   op_POPX(self);   break;
+    case PUSHX:  op_PUSHX(self);  break;
     default:     cpue_muda_erro(self->estado, ERR_INSTR_INV, 0);
   }
 

--- a/t0/exec.c
+++ b/t0/exec.c
@@ -275,13 +275,6 @@ static void op_ESCR(exec_t *self) // escrita de E/S
   }
 }
 
-static void op_ESCR(exec_t *self) // escrita de E/S
-{
-  int A1;
-  if (pega_A1(self, &A1) && poe_es(self, A1, cpue_A(self->estado))) {
-    incrementa_PC2(self);
-  }
-}
 static void op_CMPA(exec_t *self) // compara A com A1
 {
   int A1, mA1;
@@ -315,6 +308,8 @@ static void op_DESVE(exec_t *self) // desvio condicional
     incrementa_PC2(self);
   }
 }
+
+#include <stdio.h>
 
 
 err_t exec_executa_1(exec_t *self)

--- a/t0/exec.c
+++ b/t0/exec.c
@@ -15,6 +15,7 @@ exec_t *exec_cria(mem_t *mem, es_t *es)
   self = malloc(sizeof(*self));
   if (self != NULL) {
     self->estado = cpue_cria();
+    cpue_muda_SP(self->estado,mem_heap(mem));
     self->mem = mem;
     self->es = es;
   }
@@ -308,6 +309,28 @@ static void op_DESVE(exec_t *self) // desvio condicional
     incrementa_PC2(self);
   }
 }
+static void op_PUSHA(exec_t *self) // desvio condicional
+{
+  int sp = cpue_SP(self->estado);
+  if(poe_mem(self, sp,cpue_A(self->estado))){
+    cpue_muda_SP(sp+1);
+    incrementa_PC2(self);
+  }else{
+    cpue_muda_erro(self->estado, ERR_ESTOURO_PILHA, sp);
+  }
+}
+static void op_POPA(exec_t *self) // desvio condicional
+{
+  int sp = cpue_SP(self->estado);
+  int val;
+  if(mem_heap(self->mem)<sp && pega_mem(self, sp-1,&val)){
+    cpue_muda_SP(self,sp-1);
+    cpue_muda_A(self,val);
+    incrementa_PC2(self);
+  }else{
+    cpue_muda_erro(self->estado, ERR_ESTOURO_PILHA, sp);
+  }
+}
 
 #include <stdio.h>
 
@@ -346,6 +369,8 @@ err_t exec_executa_1(exec_t *self)
     case DESVA:  op_DESVA(self);  break;
     case DESVB:  op_DESVB(self);  break;
     case DESVE:  op_DESVE(self);  break;
+    case POPA:   op_POPA(self);   break;
+    case PUSHA:  op_PUSHA(self);  break;
     default:     cpue_muda_erro(self->estado, ERR_INSTR_INV, 0);
   }
 

--- a/t0/exec.c
+++ b/t0/exec.c
@@ -313,7 +313,7 @@ static void op_PUSHA(exec_t *self) // desvio condicional
 {
   int sp = cpue_SP(self->estado);
   if(poe_mem(self, sp,cpue_A(self->estado))){
-    cpue_muda_SP(sp+1);
+    cpue_muda_SP(self->estado,sp+1);
     incrementa_PC2(self);
   }else{
     cpue_muda_erro(self->estado, ERR_ESTOURO_PILHA, sp);
@@ -324,8 +324,8 @@ static void op_POPA(exec_t *self) // desvio condicional
   int sp = cpue_SP(self->estado);
   int val;
   if(mem_heap(self->mem)<sp && pega_mem(self, sp-1,&val)){
-    cpue_muda_SP(self,sp-1);
-    cpue_muda_A(self,val);
+    cpue_muda_SP(self->estado,sp-1);
+    cpue_muda_A(self->estado,val);
     incrementa_PC2(self);
   }else{
     cpue_muda_erro(self->estado, ERR_ESTOURO_PILHA, sp);

--- a/t0/exec.c
+++ b/t0/exec.c
@@ -275,6 +275,47 @@ static void op_ESCR(exec_t *self) // escrita de E/S
   }
 }
 
+static void op_ESCR(exec_t *self) // escrita de E/S
+{
+  int A1;
+  if (pega_A1(self, &A1) && poe_es(self, A1, cpue_A(self->estado))) {
+    incrementa_PC2(self);
+  }
+}
+static void op_CMPA(exec_t *self) // compara A com A1
+{
+  int A1, mA1;
+  if (pega_A1(self, &A1) && pega_mem(self, A1, &mA1)) {
+    cpue_define_status_flag(self->estado,cpue_A(self->estado)-mA1);
+    incrementa_PC2(self);
+  }
+}
+
+static void op_DESVA(exec_t *self) // desvio condicional
+{
+  if (cpue_verifica_maior_flag(self->estado)!=0) {
+    op_DESV(self);
+  } else {
+    incrementa_PC2(self);
+  }
+}
+static void op_DESVB(exec_t *self) // desvio condicional
+{
+  if (cpue_verifica_menor_flag(self->estado)!=0) {
+    op_DESV(self);
+  } else {
+    incrementa_PC2(self);
+  }
+}
+static void op_DESVE(exec_t *self) // desvio condicional
+{
+  if (cpue_verifica_igual_flag(self->estado)!=0) {
+    op_DESV(self);
+  } else {
+    incrementa_PC2(self);
+  }
+}
+
 
 err_t exec_executa_1(exec_t *self)
 {
@@ -306,6 +347,10 @@ err_t exec_executa_1(exec_t *self)
     case DESVNZ: op_DESVNZ(self); break;
     case LE:     op_LE(self);     break;
     case ESCR:   op_ESCR(self);   break;
+    case CMPA:   op_CMPA(self);   break;
+    case DESVA:  op_DESVA(self);  break;
+    case DESVB:  op_DESVB(self);  break;
+    case DESVE:  op_DESVE(self);  break;
     default:     cpue_muda_erro(self->estado, ERR_INSTR_INV, 0);
   }
 

--- a/t0/exec.h
+++ b/t0/exec.h
@@ -17,29 +17,7 @@
 typedef struct exec_t exec_t; // tipo opaco
 
 // os códigos das instruções que nossa CPU sabe executar
-typedef enum {
-  NOP    =  0, // 1 não faz nada
-  PARA   =  1, // 1 para a CPU           modo=ERR_CPU_PARADA
-  CARGI  =  2, // 2 carrega imediato     A=A1
-  CARGM  =  3, // 2 carrega da memória   A=mem[A1]
-  CARGX  =  4, // 2 carrega indexado     A=mem[A1+X]
-  ARMM   =  5, // 2 armazena na memória  mem[A1]=A
-  ARMX   =  6, // 2 armazena indexado    mem[A1+X]=A
-  MVAX   =  7, // 1 copia A para X       X=A
-  MVXA   =  8, // 1 copia X para A       A=X
-  INCX   =  9, // 1 incrementa X         X++
-  SOMA   = 10, // 2 soma                 A+=mem[A1]
-  SUB    = 11, // 2 subtrai              A-=mem[A1]
-  MULT   = 12, // 2 multiplica           A*=mem[A1]
-  DIV    = 13, // 2 divide               A/=mem[A1]
-  RESTO  = 14, // 2 calcula o resto      A%=mem[A1]
-  NEG    = 15, // 1 inverte o sinal      A=-A
-  DESV   = 16, // 2 desvio               PC=A1
-  DESVZ  = 17, // 2 desvio condicional   se A for 0, PC=A1
-  DESVNZ = 18, // 2 desvio condicional   se A não for 0, PC=A1
-  LE     = 19, // 2 leitura de E/S       A=es[A1]
-  ESCR   = 20, // 2 escrita de E/S       es[A1]=A
-} opcode_t;
+#include "opcode.h"
 
 // cria uma unidade de execução com acesso à memória e ao
 //   controlador de E/S fornecidos

--- a/t0/mem.c
+++ b/t0/mem.c
@@ -5,15 +5,18 @@
 struct mem_t {
   int tam;
   int *conteudo;
+  int comeco_heap;
 };
 
-mem_t *mem_cria(int tam)
+mem_t *mem_cria(int tam,int heapsize)
 {
   mem_t *self;
   self = malloc(sizeof(*self));
+  tam+=heapsize;
   if (self != NULL) {
     self->tam = tam;
     self->conteudo = malloc(tam * sizeof(*(self->conteudo)));
+    self->comeco_heap = tam;
     if (self->conteudo == NULL) {
       free(self);
       self = NULL;
@@ -30,6 +33,10 @@ void mem_destroi(mem_t *self)
     }
     free(self);
   }
+}
+
+int mem_heap(mem_t *self){
+  return self->comeco_heap;
 }
 
 int mem_tam(mem_t *self)

--- a/t0/mem.c
+++ b/t0/mem.c
@@ -12,11 +12,10 @@ mem_t *mem_cria(int tam,int heapsize)
 {
   mem_t *self;
   self = malloc(sizeof(*self));
-  tam+=heapsize;
   if (self != NULL) {
-    self->tam = tam;
-    self->conteudo = malloc(tam * sizeof(*(self->conteudo)));
     self->comeco_heap = tam;
+    self->tam = tam+heapsize;
+    self->conteudo = malloc(self->tam * sizeof(*(self->conteudo)));
     if (self->conteudo == NULL) {
       free(self);
       self = NULL;

--- a/t0/mem.h
+++ b/t0/mem.h
@@ -22,6 +22,9 @@ void mem_destroi(mem_t *self);
 // retorna o tamanho da região de memória (número de valores que comporta)
 int mem_tam(mem_t *self);
 
+// retorna o endereço que começa a memoria heap
+int mem_heap(mem_t *self);
+
 // coloca na posição apontada por 'pvalor' o valor no endereço 'endereco'
 // retorna erro ERR_END_INV (e não altera '*pvalor') se endereço inválido
 err_t mem_le(mem_t *self, int endereco, int *pvalor);

--- a/t0/mem.h
+++ b/t0/mem.h
@@ -13,7 +13,7 @@ typedef struct mem_t mem_t;
 // retorna um ponteiro para um descritor, que deverá ser usado em todas
 //   as operações sobre essa memória
 // retorna NULL em caso de erro
-mem_t *mem_cria(int tam);
+mem_t *mem_cria(int tam,int heap);
 
 // destrói uma região de memória
 // nenhuma outra operação pode ser realizada na região após esta chamada

--- a/t0/montador.c
+++ b/t0/montador.c
@@ -251,7 +251,7 @@ void monta_linha(int linha, char *label, char *instrucao, char *arg)
   // pseudo-instrução DEFINE tem que ser tratada antes, porque não pode
   //   definir o label de forma normal
   
-  if (num_instr == DEFINE) {
+  if (instrucoes[num_instr].opcode == DEFINE) {
     int argn;  // para conter o valor numérico do argumento
     if (label == NULL) {
       fprintf(stderr, "ERRO: linha %d: 'DEFINE' exige um label\n",

--- a/t0/montador.c
+++ b/t0/montador.c
@@ -155,42 +155,43 @@ void ref_resolve(void)
 //   DEFINE - define um valor para um símbolo (obrigatoriamente tem que ter
 //            um label, que é definido com o valor do argumento e não com a
 //            posição atual da memória) -- ainda não implementado
-
-typedef enum {
-  NOP,    PARA,   CARGI,  CARGM,  CARGX,  ARMM,   ARMX,   MVAX,
-  MVXA,   INCX,   SOMA,   SUB,    MULT,   DIV,    RESTO,  NEG,
-  DESV,   DESVZ,  DESVNZ, LE,     ESCR,
-  VALOR,  ESPACO, DEFINE,
-} opcode_t;
+#include "opcode.h"
 struct {
   char *nome;
   int num_args;
+  int opcode;
 } instrucoes[] = {
-  { "NOP",    0 },
-  { "PARA",   0 },
-  { "CARGI",  1 },
-  { "CARGM",  1 },
-  { "CARGX",  1 },
-  { "ARMM",   1 },
-  { "ARMX",   1 },
-  { "MVAX",   0 },
-  { "MVXA",   0 },
-  { "INCX",   0 },
-  { "SOMA",   1 },
-  { "SUB",    1 },
-  { "MULT",   1 },
-  { "DIV",    1 },
-  { "RESTO",  1 },
-  { "NEG",    0 },
-  { "DESV",   1 },
-  { "DESVZ",  1 },
-  { "DESVNZ", 1 },
-  { "LE",     1 },
-  { "ESCR",   1 },
+  { "NOP",    0,  NOP },
+  { "PARA",   0,  PARA},
+  { "CARGI",  1,  CARGI },
+  { "CARGM",  1,  CARGM },
+  { "CARGX",  1,  CARGX },
+  { "ARMM",   1,  ARMM },
+  { "ARMX",   1,  ARMX },
+  { "MVAX",   0,  MVAX },
+  { "MVXA",   0,  MVXA },
+  { "INCX",   0,  INCX },
+  { "SOMA",   1,  SOMA },
+  { "SUB",    1,  SUB },
+  { "MULT",   1,  MULT },
+  { "DIV",    1,  DIV },
+  { "RESTO",  1,  RESTO },
+  { "NEG",    0,  NEG },
+  { "DESV",   1,  DESV },
+  { "DESVZ",  1,  DESVZ },
+  { "DESVNZ", 1,  DESVNZ },
+  { "LE",     1,  LE },
+  { "ESCR",   1,  ESCR },
   // pseudo-instrucoes
-  { "VALOR",  1 },
-  { "ESPACO", 1 },
-  { "DEFINE", 1 },
+  { "VALOR",  1,  VALOR },
+  { "ESPACO", 1,  ESPACO },
+  { "DEFINE", 1,  DEFINE },
+
+  // Instruções de comparação e pulo condicional
+  { "CMPA",   1,  CMPA },
+  { "DESVA",  1,  DESVA },
+  { "DESVB",  1,  DESVB },
+  { "DESVE",  1,  DESVE },
 };
 #define INSTR_NUM (sizeof(instrucoes)/sizeof(instrucoes[0]))
 
@@ -210,9 +211,10 @@ int instr_opcode(char *nome)
 
 // realiza a montagem de uma instrução (gera o código para ela na memória),
 //   tendo opcode e argumento
-void monta_instrucao(int linha, int opcode, char *arg)
+void monta_instrucao(int linha, int num_instr, char *arg)
 {
   int argn;  // para conter o valor numérico do argumento
+  int opcode = instrucoes[num_instr].opcode;
   
   // trata pseudo-opcodes antes
   if (opcode == ESPACO) {
@@ -231,7 +233,7 @@ void monta_instrucao(int linha, int opcode, char *arg)
     // instrução real, coloca o opcode da instrução na memória
     mem_insere(opcode);
   }
-  if (instrucoes[opcode].num_args == 0) {
+  if (instrucoes[num_instr].num_args == 0) {
     return;
   }
   if (tem_numero(arg, &argn)) {
@@ -248,6 +250,7 @@ void monta_linha(int linha, char *label, char *instrucao, char *arg)
   int num_instr = instr_opcode(instrucao);
   // pseudo-instrução DEFINE tem que ser tratada antes, porque não pode
   //   definir o label de forma normal
+  
   if (num_instr == DEFINE) {
     int argn;  // para conter o valor numérico do argumento
     if (label == NULL) {

--- a/t0/montador.c
+++ b/t0/montador.c
@@ -192,6 +192,11 @@ struct {
   { "DESVA",  1,  DESVA },
   { "DESVB",  1,  DESVB },
   { "DESVE",  1,  DESVE },
+
+  { "PUSHA",  0,  PUSHA },
+  { "POPA",   0,  POPA },
+  { "PUSHX",  0,  PUSHX },
+  { "POPX",   0,  POPX },
 };
 #define INSTR_NUM (sizeof(instrucoes)/sizeof(instrucoes[0]))
 

--- a/t0/opcode.h
+++ b/t0/opcode.h
@@ -38,7 +38,7 @@
 
         PUSHA  = 25,
         POPA   = 26,
-        PUSHX  = 25,
-        POPX   = 26,
+        PUSHX  = 27,
+        POPX   = 28,
     } opcode_t;
 #endif

--- a/t0/opcode.h
+++ b/t0/opcode.h
@@ -35,5 +35,10 @@
         DESVA  = 22,
         DESVB  = 23,
         DESVE  = 24,
+
+        PUSHA  = 25,
+        POPA   = 26,
+        PUSHX  = 25,
+        POPX   = 26,
     } opcode_t;
 #endif

--- a/t0/opcode.h
+++ b/t0/opcode.h
@@ -1,0 +1,39 @@
+#ifndef OPCODE_H
+#define OPCODE_H
+
+    typedef enum {
+        // pseudo-instruções
+        DEFINE = -1,
+        VALOR  = -2,
+        ESPACO = -3,
+        
+
+
+        NOP    =  0, // 1 não faz nada
+        PARA   =  1, // 1 para a CPU           modo=ERR_CPU_PARADA
+        CARGI  =  2, // 2 carrega imediato     A=A1
+        CARGM  =  3, // 2 carrega da memória   A=mem[A1]
+        CARGX  =  4, // 2 carrega indexado     A=mem[A1+X]
+        ARMM   =  5, // 2 armazena na memória  mem[A1]=A
+        ARMX   =  6, // 2 armazena indexado    mem[A1+X]=A
+        MVAX   =  7, // 1 copia A para X       X=A
+        MVXA   =  8, // 1 copia X para A       A=X
+        INCX   =  9, // 1 incrementa X         X++
+        SOMA   = 10, // 2 soma                 A+=mem[A1]
+        SUB    = 11, // 2 subtrai              A-=mem[A1]
+        MULT   = 12, // 2 multiplica           A*=mem[A1]
+        DIV    = 13, // 2 divide               A/=mem[A1]
+        RESTO  = 14, // 2 calcula o resto      A%=mem[A1]
+        NEG    = 15, // 1 inverte o sinal      A=-A
+        DESV   = 16, // 2 desvio               PC=A1
+        DESVZ  = 17, // 2 desvio condicional   se A for 0, PC=A1
+        DESVNZ = 18, // 2 desvio condicional   se A não for 0, PC=A1
+        LE     = 19, // 2 leitura de E/S       A=es[A1]
+        ESCR   = 20, // 2 escrita de E/S       es[A1]=A
+        
+        CMPA   = 21,
+        DESVA  = 22,
+        DESVB  = 23,
+        DESVE  = 24,
+    } opcode_t;
+#endif

--- a/t0/teste.c
+++ b/t0/teste.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#define MEMORIA_HEAP 64
+
 // funções auxiliares
 mem_t *init_mem(void);
 void imprime_estado(exec_t *exec);
@@ -57,7 +59,7 @@ mem_t *init_mem(void)
   int tam_progr = sizeof(progr)/sizeof(progr[0]);
                 
   // cria uma memória e inicializa com o programa 
-  mem_t *mem = mem_cria(tam_progr);
+  mem_t *mem = mem_cria(tam_progr,TAM_PILHA);
   for (int i = 0; i < tam_progr; i++) {
     if (mem_escreve(mem, i, progr[i]) != ERR_OK) {
       printf("Erro de memória, endereco %d\n", i);

--- a/t0/teste.c
+++ b/t0/teste.c
@@ -59,7 +59,7 @@ mem_t *init_mem(void)
   int tam_progr = sizeof(progr)/sizeof(progr[0]);
                 
   // cria uma memória e inicializa com o programa 
-  mem_t *mem = mem_cria(tam_progr,TAM_PILHA);
+  mem_t *mem = mem_cria(tam_progr,MEMORIA_HEAP);
   for (int i = 0; i < tam_progr; i++) {
     if (mem_escreve(mem, i, progr[i]) != ERR_OK) {
       printf("Erro de memória, endereco %d\n", i);


### PR DESCRIPTION
Sugestão para modificação do simulador para facilitar a implementação de código de máquina para alguns algoritmos.

Modificações feitas nesse pull request:
- Feito a refatoração do enum de opcodes para que seja centralizado em um arquivo independente, dessa forma ao adicionar um comando com um valor de opcode, tanto o montador quanto o executor vão ter a mesma referencia e vão executar corretamente.
- Adicionado no estado da cpu flags. Basicamente isso possibilita definir estados binários na cpu e consulta-las se está ativou ou não determinado estado. Essa flag é usada por essa branch principalmente para armazenar o estado da ultima comparação. Mais detalhes abaixo.
- Adicionado comando CMPA, que faz uma comparação de A com [A1] e altera as flags de acordo. Segue a [instrução real](https://www.felixcloutier.com/x86/cmp) que usei como referencia e adaptei para a estrutura de cpu do professor.
- Adicionado comando DESVA (Desviso se A é maior), DESVB (Desvio se B é maior), DESVE (Desvio se é igual) no conjunto de instruções. Facilitando fazer comparações, é possivel também adicionar os comandos DESVAE (Desvio se A é maior ou igual a B), DESVBE (Desvio se B é maior ou igual a A) utilizando as mesmas flags, porém para deixar simples o conjunto de instruções nesse pull request foi adicionado só os 3 anteriormente citados.  

Fiz alguns testes da utilização dos comandos, e da fatoração e está dando as saidas corretas, porém novos testes são sempre bem vindos. 
